### PR TITLE
Set the default port to an empty string

### DIFF
--- a/Sources/christoph.jsonsender.sdPlugin/code.html
+++ b/Sources/christoph.jsonsender.sdPlugin/code.html
@@ -11,7 +11,7 @@
     /***
      * Use this function to send some json to whereever
      ***/
-      var json_sender = (method, address='http://127.0.0.1', port=80, header={"content-type":"application/json"}, payload) => {
+      var json_sender = (method, address='http://127.0.0.1', port='', header={"content-type":"application/json"}, payload) => {
         var separator = (port === "") ? "" : ":";
 
         $.ajax({


### PR DESCRIPTION
Resolves a bug where if you provided no port there was always a trailing colon in the sent string, which upsets Home Assistant:
http://myHost/MyPath: